### PR TITLE
fix simple assignment's handling of alignment

### DIFF
--- a/semantics/language/translation/expr/assignment.k
+++ b/semantics/language/translation/expr/assignment.k
@@ -67,12 +67,10 @@ module C-EXPR-ASSIGNMENT
      rule L:KResult := (R:RValue => cast(type(L), R))
           requires isPointerType(type(L)) andBool isPointerType(type(R))
                andBool areCompatible(
-                    stripQualifiers(stripAlignas(innerType(type(L)))),
-                    stripQualifiers(stripAlignas(innerType(type(R)))))
+                    stripQualifiers(innerType(type(L))),
+                    stripQualifiers(innerType(type(R))))
                andBool getQualifiers(innerType(type(R)))
                     <=Set getQualifiers(innerType(type(L)))
-               andBool getAlignas(innerType(type(L)))
-                    <=Int getAlignas(innerType(type(R)))
                andBool (type(L) =/=Type type(R))
 
      rule L:KResult := (R:RValue => cast(type(L), R))
@@ -126,12 +124,10 @@ module C-EXPR-ASSIGNMENT
                andBool notBool isVoidType(innerType(type(R)))
                andBool (
                     notBool areCompatible(
-                         stripQualifiers(stripAlignas(innerType(type(L)))),
-                         stripQualifiers(stripAlignas(innerType(type(R)))))
+                         stripQualifiers(innerType(type(L))),
+                         stripQualifiers(innerType(type(R))))
                     orBool notBool (getQualifiers(innerType(type(R)))
                          <=Set getQualifiers(innerType(type(L))))
-                    orBool getAlignas(innerType(type(L)))
-                         >Int getAlignas(innerType(type(R)))
                )
      rule (.K => CV("TEAS3", "lvalue required as left operand in assignment.", "6.5.16:2"))
           ~> tv(_, _) := _:RValue

--- a/tests/unit-fail-compilation/j025b.c
+++ b/tests/unit-fail-compilation/j025b.c
@@ -2,7 +2,7 @@ int main(void) {
       _Alignas(32) int x;
       _Alignas(32) int *p;
 
-      int y;
+      _Alignas(32) int y;
       int *q;
 
       p = &x;

--- a/tests/unit-fail-compilation/j025b.ref
+++ b/tests/unit-fail-compilation/j025b.ref
@@ -1,0 +1,7 @@
+File: j025b.c
+Line: 9
+Error: CEAS2
+Description: incompatible pointer types in assignment or function call arguments.
+Type: Constraint violation.
+See also: C11 sec. 6.5.16.1:1
+Translation failed. Run kcc -d j025b.c to see commands run.


### PR DESCRIPTION
@chathhorn can you include this patch in your diff before you merge it? The test in question was actually wrong before: the C standard says that a type declared without an alignas specifier is not compatible with an unspecified version of that type, regardless of whether they have compatible underlying alignments.
